### PR TITLE
ci: GitHub Actions ECR push workflow

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -1,0 +1,109 @@
+name: Build and Push to ECR
+
+on:
+  push:
+    branches: [dev, main, master]
+  pull_request:
+    branches: [dev, main, master]
+
+env:
+  AWS_REGION: ap-south-1
+  ECR_REGISTRY: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.ap-south-1.amazonaws.com
+
+jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      services: ${{ steps.filter.outputs.changes }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            api-gateway:
+              - 'apps/api-gateway/**'
+              - 'packages/**'
+              - 'Dockerfile'
+            auth-service:
+              - 'apps/auth-service/**'
+              - 'packages/**'
+              - 'Dockerfile'
+            user-service:
+              - 'apps/user-service/**'
+              - 'packages/**'
+              - 'Dockerfile'
+            job-service:
+              - 'apps/job-service/**'
+              - 'packages/**'
+              - 'Dockerfile'
+            application-service:
+              - 'apps/application-service/**'
+              - 'packages/**'
+              - 'Dockerfile'
+            notification-service:
+              - 'apps/notification-service/**'
+              - 'packages/**'
+              - 'Dockerfile'
+            payment-service:
+              - 'apps/payment-service/**'
+              - 'packages/**'
+              - 'Dockerfile'
+            admin-service:
+              - 'apps/admin-service/**'
+              - 'packages/**'
+              - 'Dockerfile'
+            messaging-service:
+              - 'apps/messaging-service/**'
+              - 'packages/**'
+              - 'Dockerfile'
+            recommendation-service:
+              - 'apps/recommendation-service/**'
+              - 'packages/**'
+              - 'Dockerfile'
+
+  build-push:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.services != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        service: ${{ fromJson(needs.detect-changes.outputs.services) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.ECR_REGISTRY }}/ai-job-portal/${{ matrix.service }}
+          tags: |
+            type=sha,prefix=
+            type=ref,event=branch
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main' }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: ${{ github.event_name == 'push' }}
+          build-args: SERVICE=${{ matrix.service }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow to build and push Docker images to AWS ECR
- Path filtering: only rebuilds services with code changes
- Docker layer caching for faster builds

## AWS Resources Created
- 10 ECR repositories: `ai-job-portal/{service-name}`
- IAM user: `github-actions-ecr` with ECR PowerUser policy

## GitHub Secrets Added
- `AWS_ACCESS_KEY_ID`
- `AWS_SECRET_ACCESS_KEY`
- `AWS_ACCOUNT_ID`

## Workflow Triggers
- Push to `dev`, `main`, `master`
- Pull requests to these branches (build only, no push)

## Test plan
- [x] ECR repos created
- [x] IAM user created with permissions
- [x] GitHub secrets configured
- [ ] Merge PR → workflow triggers → images pushed to ECR