### PR TITLE
feat: AWS Amplify config for frontend deployment

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -1,0 +1,20 @@
+version: 1
+applications:
+  - appRoot: apps/job-board-web
+    frontend:
+      phases:
+        preBuild:
+          commands:
+            - nvm use 20
+            - npm ci
+        build:
+          commands:
+            - npm run build
+      artifacts:
+        baseDirectory: .next
+        files:
+          - '**/*'
+      cache:
+        paths:
+          - node_modules/**/*
+          - .next/cache/**/*

--- a/apps/job-board-web/.env.example
+++ b/apps/job-board-web/.env.example
@@ -1,0 +1,4 @@
+# Frontend environment variables (set in Amplify Console)
+NEXT_PUBLIC_NODE_ENV=production
+NEXT_PUBLIC_API_BASE_URL_DEV=http://localhost:3000/api/v1
+NEXT_PUBLIC_API_BASE_URL_LIVE=https://<ALB-DNS-or-API-Gateway>/api/v1

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -72,6 +72,8 @@ services:
       - ADMIN_SERVICE_URL=http://admin-service:3007
       - MESSAGING_SERVICE_URL=http://messaging-service:3008
       - RECOMMENDATION_SERVICE_URL=http://recommendation-service:3009
+      - CORS_ORIGINS=${CORS_ORIGINS:-*}
+      - JWT_SECRET=${JWT_SECRET}
     depends_on:
       - auth-service
       - user-service


### PR DESCRIPTION
## Summary
- Add `amplify.yml` build spec for monorepo Next.js deployment
- Add `.env.example` documenting required Amplify env vars
- Add `CORS_ORIGINS` + `JWT_SECRET` env vars to api-gateway in docker-compose

## Amplify Setup Steps (manual in AWS Console)
1. Connect GitHub repo to Amplify → set app root to `apps/job-board-web`
2. Set env vars: `NEXT_PUBLIC_NODE_ENV=production`, `NEXT_PUBLIC_API_BASE_URL_LIVE=<ALB-URL>`
3. Configure branch deployments: `master` → production
4. Custom domain once client provides DNS access

## Test plan
- [ ] Verify Amplify detects `amplify.yml` and builds correctly
- [ ] Verify SSR pages render on Amplify
- [ ] Verify API calls reach backend (CORS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added AWS Amplify deployment configuration for the web application
  * Created environment configuration templates for frontend services
  * Extended API gateway environment settings for deployment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->