### PR TITLE
feat: database enums and implement Apple OAuth authentication via Cog…

### DIFF
--- a/apps/auth-service/src/oauth/oauth.controller.ts
+++ b/apps/auth-service/src/oauth/oauth.controller.ts
@@ -8,12 +8,36 @@ import {
   HttpStatus,
   BadRequestException,
 } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiQuery, ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiQuery,
+  ApiProperty,
+  ApiPropertyOptional,
+} from '@nestjs/swagger';
 import { IsString, IsNotEmpty, IsOptional, IsEnum } from 'class-validator';
 import { OAuthService } from './oauth.service';
 import { Public } from '@ai-job-portal/common';
 
 class GoogleCallbackDto {
+  @ApiProperty({ description: 'Authorization code from Cognito redirect' })
+  @IsString()
+  @IsNotEmpty()
+  code: string;
+
+  @ApiProperty({ description: 'Must match the redirectUri used in the initial request' })
+  @IsString()
+  @IsNotEmpty()
+  redirectUri: string;
+
+  @ApiPropertyOptional({ enum: ['candidate', 'employer'], default: 'candidate' })
+  @IsOptional()
+  @IsEnum(['candidate', 'employer'])
+  role?: 'candidate' | 'employer';
+}
+
+class AppleCallbackDto {
   @ApiProperty({ description: 'Authorization code from Cognito redirect' })
   @IsString()
   @IsNotEmpty()
@@ -53,10 +77,7 @@ export class OAuthController {
   @ApiQuery({ name: 'redirectUri', required: true, description: 'Frontend callback URL' })
   @ApiQuery({ name: 'role', enum: ['candidate', 'employer'], required: false })
   @ApiResponse({ status: 200, description: 'Returns Cognito hosted UI URL for Google login' })
-  getGoogleAuthUrl(
-    @Query('redirectUri') redirectUri: string,
-    @Query('role') role?: string,
-  ) {
+  getGoogleAuthUrl(@Query('redirectUri') redirectUri: string, @Query('role') role?: string) {
     if (!redirectUri) {
       throw new BadRequestException('redirectUri is required');
     }
@@ -82,8 +103,31 @@ export class OAuthController {
   @ApiOperation({ summary: 'Google Sign-In for mobile apps (native SDK)' })
   @ApiResponse({ status: 200, description: 'Returns auth tokens and user data' })
   async googleNative(@Body() dto: GoogleNativeDto) {
-    return this.oauthService.handleGoogleNativeLogin(
-      dto.idToken,
+    return this.oauthService.handleGoogleNativeLogin(dto.idToken, dto.role || 'candidate');
+  }
+
+  @Get('apple')
+  @Public()
+  @ApiOperation({ summary: 'Get Apple OAuth URL (Cognito Hosted UI)' })
+  @ApiQuery({ name: 'redirectUri', required: true, description: 'Frontend callback URL' })
+  @ApiQuery({ name: 'role', enum: ['candidate', 'employer'], required: false })
+  @ApiResponse({ status: 200, description: 'Returns Cognito hosted UI URL for Apple login' })
+  getAppleAuthUrl(@Query('redirectUri') redirectUri: string, @Query('role') role?: string) {
+    if (!redirectUri) {
+      throw new BadRequestException('redirectUri is required');
+    }
+    return this.oauthService.getAppleAuthUrl(redirectUri, role || 'candidate');
+  }
+
+  @Post('apple/callback')
+  @Public()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Exchange Cognito authorization code (Apple) for app tokens' })
+  @ApiResponse({ status: 200, description: 'Returns auth tokens and user data' })
+  async appleCallback(@Body() dto: AppleCallbackDto) {
+    return this.oauthService.handleCognitoAppleCallback(
+      dto.code,
+      dto.redirectUri,
       dto.role || 'candidate',
     );
   }

--- a/apps/auth-service/src/oauth/oauth.service.ts
+++ b/apps/auth-service/src/oauth/oauth.service.ts
@@ -16,7 +16,7 @@ import { DATABASE_CLIENT } from '../database/database.module';
 import { AuthTokens, JwtPayload } from '../auth/interfaces';
 
 export interface SocialProfile {
-  provider: 'google' | 'linkedin';
+  provider: 'google' | 'linkedin' | 'apple';
   providerId: string;
   email: string;
   firstName?: string;
@@ -195,6 +195,73 @@ export class OAuthService {
     };
   }
 
+  /**
+   * Returns the Cognito Hosted UI URL for Apple OAuth login
+   */
+  getAppleAuthUrl(redirectUri: string, role: string) {
+    const url = this.cognitoService.getAuthorizationUrl('SignInWithApple', redirectUri);
+    const stateParam = `&state=${encodeURIComponent(JSON.stringify({ role }))}`;
+    return { url: url + stateParam };
+  }
+
+  /**
+   * Exchange Cognito authorization code for tokens (Apple Sign In),
+   * parse ID token, create/find user, and return app auth tokens
+   */
+  async handleCognitoAppleCallback(
+    code: string,
+    redirectUri: string,
+    role: 'candidate' | 'employer',
+  ) {
+    const cognitoTokens = await this.cognitoService.exchangeCodeForTokens(code, redirectUri);
+    const idTokenPayload = this.cognitoService.parseIdToken(cognitoTokens.idToken);
+
+    this.logger.log(`Apple OAuth: ${idTokenPayload.email} (sub: ${idTokenPayload.sub})`);
+
+    const profile: SocialProfile = {
+      provider: 'apple',
+      providerId: idTokenPayload.sub,
+      email: idTokenPayload.email,
+      firstName: idTokenPayload.givenName,
+      lastName: idTokenPayload.familyName,
+      // Apple does not provide profile photos
+    };
+
+    const authTokens = await this.handleSocialLogin(profile, role);
+
+    const user = await this.db.query.users.findFirst({
+      where: eq(users.id, authTokens.userId),
+    });
+
+    const [profilePhoto, company] = await Promise.all([
+      this.getProfilePhotoForUser(user!.id, user!.role),
+      this.getCompanyInfoForUser(user!.id, user!.role),
+    ]);
+
+    return {
+      message: 'Login successful',
+      data: {
+        accessToken: authTokens.accessToken,
+        refreshToken: authTokens.refreshToken,
+        expiresIn: authTokens.expiresIn,
+        user: {
+          userId: user!.id,
+          role: user!.role,
+          firstName: user!.firstName || '',
+          lastName: user!.lastName || '',
+          email: user!.email,
+          mobile: user!.mobile || '',
+          company,
+          profilePhoto,
+          isVerified: user!.isVerified || false,
+          isMobileVerified: user!.isMobileVerified || false,
+          onboardingStep: user!.onboardingStep || 0,
+          isOnboardingCompleted: user!.isOnboardingCompleted || false,
+        },
+      },
+    };
+  }
+
   async handleSocialLogin(
     profile: SocialProfile,
     role: 'candidate' | 'employer' = 'candidate',
@@ -202,7 +269,10 @@ export class OAuthService {
     // Check if social login exists
     const existingSocialLogin = await this.db.query.socialLogins.findFirst({
       where: and(
-        eq(socialLogins.provider, profile.provider),
+        eq(
+          socialLogins.provider,
+          profile.provider as (typeof socialLogins.provider.enumValues)[number],
+        ),
         eq(socialLogins.providerId, profile.providerId),
       ),
     });
@@ -253,7 +323,7 @@ export class OAuthService {
       // Link social login
       await this.db.insert(socialLogins).values({
         userId,
-        provider: profile.provider,
+        provider: profile.provider as (typeof socialLogins.provider.enumValues)[number],
         providerId: profile.providerId,
         email: profile.email,
         accessToken: profile.accessToken,

--- a/packages/database/src/schema/enums.ts
+++ b/packages/database/src/schema/enums.ts
@@ -9,7 +9,7 @@ export const userRoleEnum = pgEnum('user_role', [
   'team_member',
 ]);
 export const adminRoleEnum = pgEnum('admin_role', ['super_admin', 'admin', 'moderator', 'support']);
-export const socialProviderEnum = pgEnum('social_provider', ['google', 'linkedin']);
+export const socialProviderEnum = pgEnum('social_provider', ['google', 'linkedin', 'apple']);
 export const genderEnum = pgEnum('gender', ['male', 'female', 'other', 'not_specified']);
 
 // Profile & Visibility


### PR DESCRIPTION
1. Added Apple as a social login provider using the same Cognito Hosted UI flow as Google
2. New GET /oauth/apple endpoint to generate the Cognito authorization URL for Apple Sign-In
3. New POST /oauth/apple/callback endpoint to exchange the Cognito auth code for app tokens, create/find user, and return session data
4. Added 'apple' to the social_provider database enum alongside google and linkedin