### PR TITLE
fix: resolve Swagger failed to fetch on CloudFront HTTPS

### DIFF
--- a/.env.deploy
+++ b/.env.deploy
@@ -14,8 +14,11 @@ REDIS_URL=rediss://master.ai-job-portal-dev-valkey.uxsqrz.aps1.cache.amazonaws.c
 BASE_URL=https://dev.d3tubn69g0t2tw.amplifyapp.com
 
 # CORS Configuration
-# Allow Vercel deployment and localhost for testing
-CORS_ORIGINS=https://job-board-admin-dashboard.vercel.app,http://localhost:8080,http://localhost:3000,https://dev.d107gebr3drm0w.amplifyapp.com
+# Allow CloudFront, Amplify, Vercel deployments and localhost for testing
+CORS_ORIGINS=https://d3pg92yb00eb2d.cloudfront.net,https://job-board-admin-dashboard.vercel.app,http://localhost:8080,http://localhost:3000,https://dev.d107gebr3drm0w.amplifyapp.com,https://dev.d107gebr3drm0w.amplifyapp.com
+
+# Public API base URL (CloudFront HTTPS - used for logging only, Swagger uses relative '/')
+API_BASE_URL=https://d3pg92yb00eb2d.cloudfront.net
 
 # Node Environment
 NODE_ENV=production

--- a/apps/api-gateway/src/main.ts
+++ b/apps/api-gateway/src/main.ts
@@ -151,7 +151,10 @@ async function bootstrap() {
     credentials: true,
   });
 
-  // Swagger documentation with dynamic server URL
+  // Swagger documentation
+  // Use a relative server URL ('/') so "Try it out" always targets the same
+  // origin the UI was loaded from — works correctly behind CloudFront, ALB,
+  // or localhost without any env-var dependency.
   const apiBaseUrl = process.env.API_BASE_URL || `http://localhost:${process.env.PORT || 3000}`;
   const configBuilder = new DocumentBuilder()
     .setTitle('AI Job Portal API')
@@ -161,14 +164,10 @@ async function bootstrap() {
     .addTag('auth', 'Authentication endpoints')
     .addTag('users', 'User management')
     .addTag('jobs', 'Job listings')
-    .addTag('applications', 'Job applications');
-
-  // Add appropriate server based on environment
-  if (isProduction) {
-    configBuilder.addServer(apiBaseUrl, 'Production');
-  } else {
-    configBuilder.addServer(apiBaseUrl, 'Development');
-  }
+    .addTag('applications', 'Job applications')
+    // Relative server so Swagger UI calls back to whatever host/scheme it was
+    // loaded from (CloudFront HTTPS, ALB, or localhost) without mixed-content errors.
+    .addServer('/', isProduction ? 'Production' : 'Development');
 
   const config = configBuilder.build();
   const document = SwaggerModule.createDocument(app, config);
@@ -186,7 +185,7 @@ async function bootstrap() {
   await app.listen(port, '0.0.0.0');
   logger.log(`API Gateway running on ${apiBaseUrl}`);
   logger.log(`WebSocket proxy: /socket.io/ -> ${messagingUrl}`);
-  logger.log(`Swagger docs: ${apiBaseUrl}/api/docs`);
+  logger.log(`Swagger docs: ${apiBaseUrl}/api/docs (server URL: relative '/')`);
   logger.log(`Health Dashboard: ${apiBaseUrl}/health-dashboard.html`);
   logger.log(`Environment: ${isProduction ? 'production' : 'development'}`);
 }


### PR DESCRIPTION
Swagger CORS Issue fix

`Server response
Code	Details
Undocumented
Failed to fetch.
Possible Reasons:

CORS
Network Failure
URL scheme must be "http" or "https" for CORS request.`