### PR TITLE
fix: gateway proxy timeout from 30s to  60s

### DIFF
--- a/apps/api-gateway/src/proxy/proxy.service.ts
+++ b/apps/api-gateway/src/proxy/proxy.service.ts
@@ -132,7 +132,7 @@ export class ProxyService {
           },
       maxBodyLength: Infinity,
       maxContentLength: Infinity,
-      timeout: 30000,
+      timeout: 60000,
     };
 
     try {


### PR DESCRIPTION
Gateway proxy timeout from 30s to  60s for now. Need to change once recommendation and ai parser ai purchased to higher CPU and GPU