### PR TITLE
infra: add staging env support to CI/CD workflows

### DIFF
--- a/.github/workflows/deploy-admin.yml
+++ b/.github/workflows/deploy-admin.yml
@@ -2,11 +2,19 @@ name: Deploy Admin Panel (Amplify)
 
 on:
   workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Target environment'
+        type: choice
+        options:
+          - dev
+          - staging
+        default: dev
 
 env:
   AWS_REGION: ap-south-1
   AMPLIFY_APP_ID: d107gebr3drm0w
-  BRANCH: dev
+  BRANCH: ${{ inputs.environment }}
 
 jobs:
   deploy:
@@ -45,7 +53,7 @@ jobs:
             case $STATUS in
               SUCCEED)
                 echo "Admin panel deployed successfully"
-                echo "https://dev.${{ env.AMPLIFY_APP_ID }}.amplifyapp.com"
+                echo "URL: https://${{ env.BRANCH }}.${{ env.AMPLIFY_APP_ID }}.amplifyapp.com"
                 break
                 ;;
               FAILED|CANCELLED)

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -2,11 +2,19 @@ name: Deploy Frontend (Amplify)
 
 on:
   workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Target environment'
+        type: choice
+        options:
+          - dev
+          - staging
+        default: dev
 
 env:
   AWS_REGION: ap-south-1
   AMPLIFY_APP_ID: d3tubn69g0t2tw
-  BRANCH: dev
+  BRANCH: ${{ inputs.environment }}
 
 jobs:
   deploy:
@@ -44,8 +52,8 @@ jobs:
             echo "Status: $STATUS"
             case $STATUS in
               SUCCEED)
-                echo "✅ Frontend deployed successfully"
-                echo "🌐 https://dev.${{ env.AMPLIFY_APP_ID }}.amplifyapp.com"
+                echo "Frontend deployed successfully"
+                echo "URL: https://${{ env.BRANCH }}.${{ env.AMPLIFY_APP_ID }}.amplifyapp.com"
                 break
                 ;;
               FAILED|CANCELLED)

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -3,6 +3,13 @@ name: Deploy Services to ECS
 on:
   workflow_dispatch:
     inputs:
+      environment:
+        description: 'Target environment'
+        type: choice
+        options:
+          - dev
+          - staging
+        default: dev
       api-gateway:
         description: 'API Gateway'
         type: boolean
@@ -51,7 +58,7 @@ on:
 env:
   AWS_REGION: ap-south-1
   ECR_REGISTRY: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.ap-south-1.amazonaws.com
-  ECS_CLUSTER: ai-job-portal-dev
+  ECS_CLUSTER: ai-job-portal-${{ inputs.environment }}
 
 jobs:
   prepare:

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 .env.dev
 .env.local
 .env.production
+.env.staging
+.env.deploy
 .env.*.local
 
 # Dependencies


### PR DESCRIPTION
## Summary
- Cherry-pick CI/CD staging support from master
- Adds environment selector to deploy workflows
- Enables staging deployments via GitHub Actions

## Changelog (2026-03-31)
- infra: staging env support in docker-build-push, deploy-frontend, deploy-admin workflows