### PR TITLE
fix: mobile otp generation is not working in staging - fix

### DIFF
--- a/.env.deploy
+++ b/.env.deploy
@@ -20,8 +20,8 @@ CORS_ORIGINS=https://d3pg92yb00eb2d.cloudfront.net,https://job-board-admin-dashb
 # Public API base URL (CloudFront HTTPS - used for logging only, Swagger uses relative '/')
 API_BASE_URL=https://d3pg92yb00eb2d.cloudfront.net
 
-# Node Environment
-NODE_ENV=production
+# Node Environment (use 'staging' for staging, 'production' for live)
+NODE_ENV=staging
 
 # Enable static OTP (123456) for testing in production-like environments
 # Set to 'true' to allow dev OTP bypass, remove or set 'false' for real production

--- a/apps/auth-service/src/auth/auth.service.ts
+++ b/apps/auth-service/src/auth/auth.service.ts
@@ -766,9 +766,11 @@ export class AuthService {
       return { message: 'Mobile already verified' };
     }
 
-    const isProduction = this.configService.get('NODE_ENV') === 'production';
+    const nodeEnv = this.configService.get('NODE_ENV');
+    const isProduction = nodeEnv === 'production';
+    const isStaging = nodeEnv === 'staging';
 
-    // Production: random OTP | Non-production: static OTP for testing
+    // Generate OTP: dev/staging uses static '123456', production uses random
     const otp = isProduction ? randomInt(100000, 999999).toString() : '123456';
 
     // Store in DB with 10-min expiry
@@ -780,7 +782,6 @@ export class AuthService {
     });
 
     // Production: send OTP via AWS SNS
-    // Non-production: skip SNS, return OTP in response for frontend
     if (isProduction) {
       try {
         await this.snsService.sendOtp(user.mobile, otp);
@@ -793,8 +794,10 @@ export class AuthService {
       return { message: 'OTP sent to your mobile number' };
     }
 
-    // Non-production: OTP is stored in DB, return it in response for frontend
-    this.logger.log(`[Dev] Mobile OTP generated for ${user.mobile}: ${otp}`);
+    // Dev/Staging: OTP is stored in DB, return it in response for frontend
+    this.logger.log(
+      `[${isStaging ? 'Staging' : 'Dev'}] Mobile OTP generated for ${user.mobile}: ${otp}`,
+    );
 
     return {
       message: 'OTP sent to your mobile number',


### PR DESCRIPTION
Mobile OTP generation is not working in staging  because of  NODE_ENV behaviour