### PR TITLE
fix: add missing @ai-job-portal/logger dependency to 3 services

### DIFF
--- a/apps/admin-service/package.json
+++ b/apps/admin-service/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@ai-job-portal/aws": "workspace:*",
     "@ai-job-portal/common": "workspace:*",
+    "@ai-job-portal/logger": "workspace:*",
     "@ai-job-portal/database": "workspace:*",
     "@ai-job-portal/types": "workspace:*",
     "@nestjs/common": "^10.3.0",

--- a/apps/payment-service/package.json
+++ b/apps/payment-service/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@ai-job-portal/aws": "workspace:*",
     "@ai-job-portal/common": "workspace:*",
+    "@ai-job-portal/logger": "workspace:*",
     "@ai-job-portal/database": "workspace:*",
     "@ai-job-portal/types": "workspace:*",
     "@nestjs/common": "^10.3.0",

--- a/apps/recommendation-service/package.json
+++ b/apps/recommendation-service/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@ai-job-portal/common": "workspace:*",
+    "@ai-job-portal/logger": "workspace:*",
     "@ai-job-portal/database": "workspace:*",
     "@ai-job-portal/types": "workspace:*",
     "@nestjs/axios": "^3.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -308,6 +308,9 @@ importers:
       '@ai-job-portal/database':
         specifier: workspace:*
         version: link:../../packages/database
+      '@ai-job-portal/logger':
+        specifier: workspace:*
+        version: link:../../packages/logger
       '@ai-job-portal/types':
         specifier: workspace:*
         version: link:../../packages/types
@@ -1225,6 +1228,9 @@ importers:
       '@ai-job-portal/database':
         specifier: workspace:*
         version: link:../../packages/database
+      '@ai-job-portal/logger':
+        specifier: workspace:*
+        version: link:../../packages/logger
       '@ai-job-portal/types':
         specifier: workspace:*
         version: link:../../packages/types
@@ -1331,6 +1337,9 @@ importers:
       '@ai-job-portal/database':
         specifier: workspace:*
         version: link:../../packages/database
+      '@ai-job-portal/logger':
+        specifier: workspace:*
+        version: link:../../packages/logger
       '@ai-job-portal/types':
         specifier: workspace:*
         version: link:../../packages/types


### PR DESCRIPTION
## Summary
- Added `@ai-job-portal/logger: workspace:*` to admin-service, payment-service, recommendation-service package.json
- These services import CustomLogger but were missing the workspace dependency, causing Docker build failures

## Context
Deployment of logging changes (PR #130) failed because 3 services didn't declare the logger package dependency.

## Test plan
- [ ] `pnpm install` succeeds
- [ ] Docker build for all services passes
- [ ] ECS deployment completes without module resolution errors