### PR TITLE
fix: auth-service build — UserSub typo + Dockerfile build order

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,10 +52,10 @@ COPY tsconfig.json ./
 
 # Build shared packages first (ignore errors for packages that don't exist)
 RUN pnpm --filter=@ai-job-portal/types build || true
+RUN pnpm --filter=@ai-job-portal/logger build || true
 RUN pnpm --filter=@ai-job-portal/common build || true
 RUN pnpm --filter=@ai-job-portal/database build || true
 RUN pnpm --filter=@ai-job-portal/aws build || true
-RUN pnpm --filter=@ai-job-portal/logger build || true
 RUN pnpm --filter=@ai-job-portal/video-conferencing build || true
 
 # Build the target service

--- a/apps/auth-service/src/auth/auth.service.ts
+++ b/apps/auth-service/src/auth/auth.service.ts
@@ -137,7 +137,7 @@ export class AuthService {
       phoneNumber: dto.mobile,
     });
 
-    this.logger.debug(`Registration - Cognito user created: ${cognitoResult?.UserSub}`);
+    this.logger.debug(`Registration - Cognito user created: ${cognitoResult?.userSub}`);
 
     // Parse phone number to extract country code and national number (AFTER Cognito success)
     const phoneDetails = parsePhoneDetails(dto.mobile);


### PR DESCRIPTION
## Summary
- Fix `cognitoResult.UserSub` → `userSub` (TS2551 — property name mismatch)
- Reorder Dockerfile: build logger before aws (aws imports from logger)

## Context
Auth-service Docker build failed in deploy run `23833289999`. Other 9 services passed.

## Test plan
- [ ] auth-service Docker build passes
- [ ] All 10 services deploy successfully