### PR TITLE
fix: LoggingInterceptor Fastify compat — request.get → headers

### DIFF
--- a/packages/common/src/interceptors/logging.interceptor.ts
+++ b/packages/common/src/interceptors/logging.interceptor.ts
@@ -18,7 +18,7 @@ export class LoggingInterceptor implements NestInterceptor {
   intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
     const request = context.switchToHttp().getRequest();
     const { method, url, ip } = request;
-    const userAgent = request.get('user-agent') || '';
+    const userAgent = request.headers?.['user-agent'] || '';
     const userId = request.headers['x-user-id'] || request.user?.sub || '-';
     const contentLength = request.headers['content-length'] || 0;
     const startTime = Date.now();


### PR DESCRIPTION
## Summary
- `request.get('user-agent')` is Express-only, causes `TypeError: request.get is not a function` on Fastify
- Changed to `request.headers?.['user-agent']` which works on both

## Context
All services using LoggingInterceptor return 500 on every request due to this error. Health checks failing.

## Test plan
- [ ] Health checks return 200 (not 500)
- [ ] Logs show proper HTTP request lines