### PR TITLE
fix: add no-cache option to deploy workflow

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -47,6 +47,10 @@ on:
         description: 'Deploy ALL services'
         type: boolean
         default: false
+      no-cache:
+        description: 'Build without Docker cache'
+        type: boolean
+        default: false
 
 env:
   AWS_REGION: ap-south-1
@@ -127,7 +131,8 @@ jobs:
           build-args: SERVICE=${{ matrix.service }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
+          no-cache: ${{ inputs.no-cache == true }}
+          cache-from: ${{ inputs.no-cache != true && 'type=gha' || '' }}
           cache-to: type=gha,mode=max
 
       - name: Deploy to ECS


### PR DESCRIPTION
## Summary
- Add `no-cache` boolean input to deploy workflow
- When enabled, skips Docker GHA cache (fixes stale layer issue)
- GHA cache was serving old compiled `@ai-job-portal/common` dist causing `request.get is not a function`

## Test plan
- [ ] Deploy with `no-cache=true` produces fresh Docker build
- [ ] user-service health check passes after no-cache deploy