### PR TITLE
infra: split deploy workflows for dev/staging

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,161 @@
+name: Deploy Services to ECS (Dev)
+
+on:
+  workflow_dispatch:
+    inputs:
+      api-gateway:
+        description: 'API Gateway'
+        type: boolean
+        default: false
+      auth-service:
+        description: 'Auth Service'
+        type: boolean
+        default: false
+      user-service:
+        description: 'User Service'
+        type: boolean
+        default: false
+      job-service:
+        description: 'Job Service'
+        type: boolean
+        default: false
+      application-service:
+        description: 'Application Service'
+        type: boolean
+        default: false
+      admin-service:
+        description: 'Admin Service'
+        type: boolean
+        default: false
+      notification-service:
+        description: 'Notification Service'
+        type: boolean
+        default: false
+      payment-service:
+        description: 'Payment Service'
+        type: boolean
+        default: false
+      messaging-service:
+        description: 'Messaging Service'
+        type: boolean
+        default: false
+      recommendation-service:
+        description: 'Recommendation Service'
+        type: boolean
+        default: false
+      deploy-all:
+        description: 'Deploy ALL services'
+        type: boolean
+        default: false
+      no-cache:
+        description: 'Build without Docker cache'
+        type: boolean
+        default: false
+
+env:
+  AWS_REGION: ap-south-1
+  ECR_REGISTRY: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.ap-south-1.amazonaws.com
+  ECR_PREFIX: ai-job-portal
+  ECS_CLUSTER: ai-job-portal-dev
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Build service matrix
+        id: set-matrix
+        run: |
+          services=()
+          if [[ "${{ inputs.deploy-all }}" == "true" ]]; then
+            services=("api-gateway" "auth-service" "user-service" "job-service" "application-service" "admin-service" "notification-service" "payment-service" "messaging-service" "recommendation-service")
+          else
+            [[ "${{ inputs.api-gateway }}" == "true" ]] && services+=("api-gateway")
+            [[ "${{ inputs.auth-service }}" == "true" ]] && services+=("auth-service")
+            [[ "${{ inputs.user-service }}" == "true" ]] && services+=("user-service")
+            [[ "${{ inputs.job-service }}" == "true" ]] && services+=("job-service")
+            [[ "${{ inputs.application-service }}" == "true" ]] && services+=("application-service")
+            [[ "${{ inputs.admin-service }}" == "true" ]] && services+=("admin-service")
+            [[ "${{ inputs.notification-service }}" == "true" ]] && services+=("notification-service")
+            [[ "${{ inputs.payment-service }}" == "true" ]] && services+=("payment-service")
+            [[ "${{ inputs.messaging-service }}" == "true" ]] && services+=("messaging-service")
+            [[ "${{ inputs.recommendation-service }}" == "true" ]] && services+=("recommendation-service")
+          fi
+
+          if [ ${#services[@]} -eq 0 ]; then
+            echo "::error::No services selected. Please select at least one service."
+            exit 1
+          fi
+
+          json=$(printf '%s\n' "${services[@]}" | jq -R . | jq -sc .)
+          echo "matrix={\"service\":$json}" >> $GITHUB_OUTPUT
+          echo "Deploying: ${services[*]}"
+
+  build-deploy:
+    needs: prepare
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.ECR_REGISTRY }}/${{ env.ECR_PREFIX }}/${{ matrix.service }}
+          tags: |
+            type=sha,prefix=
+            type=ref,event=branch
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          build-args: SERVICE=${{ matrix.service }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          no-cache: ${{ inputs.no-cache == true }}
+          cache-from: ${{ inputs.no-cache != true && 'type=gha' || '' }}
+          cache-to: type=gha,mode=max
+
+      - name: Deploy to ECS
+        run: |
+          IMAGE="${{ env.ECR_REGISTRY }}/${{ env.ECR_PREFIX }}/${{ matrix.service }}:latest"
+          FAMILY="${{ env.ECS_CLUSTER }}-${{ matrix.service }}"
+
+          # Get current task definition and update image
+          TASK_DEF=$(aws ecs describe-task-definition --task-definition "$FAMILY" --no-cli-pager)
+          NEW_DEF=$(echo "$TASK_DEF" | jq --arg IMG "$IMAGE" \
+            '.taskDefinition | .containerDefinitions[0].image = $IMG | del(.taskDefinitionArn,.revision,.status,.requiresAttributes,.compatibilities,.registeredAt,.registeredBy)')
+
+          # Register new task definition revision
+          NEW_ARN=$(aws ecs register-task-definition --cli-input-json "$NEW_DEF" \
+            --query 'taskDefinition.taskDefinitionArn' --output text --no-cli-pager)
+
+          # Update service with new task definition
+          aws ecs update-service \
+            --cluster ${{ env.ECS_CLUSTER }} \
+            --service ${{ matrix.service }} \
+            --task-definition "$NEW_ARN" \
+            --force-new-deployment \
+            --no-cli-pager
+
+          echo "✅ ${{ matrix.service }} deployed with $IMAGE"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,4 +1,4 @@
-name: Deploy Services to ECS
+name: Deploy Services to ECS (Staging)
 
 on:
   workflow_dispatch:
@@ -55,7 +55,8 @@ on:
 env:
   AWS_REGION: ap-south-1
   ECR_REGISTRY: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.ap-south-1.amazonaws.com
-  ECS_CLUSTER: ai-job-portal-dev
+  ECR_PREFIX: ai-job-portal-staging
+  ECS_CLUSTER: ai-job-portal-staging
 
 jobs:
   prepare:
@@ -117,7 +118,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.ECR_REGISTRY }}/ai-job-portal/${{ matrix.service }}
+          images: ${{ env.ECR_REGISTRY }}/${{ env.ECR_PREFIX }}/${{ matrix.service }}
           tags: |
             type=sha,prefix=
             type=ref,event=branch
@@ -137,9 +138,24 @@ jobs:
 
       - name: Deploy to ECS
         run: |
+          IMAGE="${{ env.ECR_REGISTRY }}/${{ env.ECR_PREFIX }}/${{ matrix.service }}:latest"
+          FAMILY="${{ env.ECS_CLUSTER }}-${{ matrix.service }}"
+
+          # Get current task definition and update image
+          TASK_DEF=$(aws ecs describe-task-definition --task-definition "$FAMILY" --no-cli-pager)
+          NEW_DEF=$(echo "$TASK_DEF" | jq --arg IMG "$IMAGE" \
+            '.taskDefinition | .containerDefinitions[0].image = $IMG | del(.taskDefinitionArn,.revision,.status,.requiresAttributes,.compatibilities,.registeredAt,.registeredBy)')
+
+          # Register new task definition revision
+          NEW_ARN=$(aws ecs register-task-definition --cli-input-json "$NEW_DEF" \
+            --query 'taskDefinition.taskDefinitionArn' --output text --no-cli-pager)
+
+          # Update service with new task definition
           aws ecs update-service \
             --cluster ${{ env.ECS_CLUSTER }} \
             --service ${{ matrix.service }} \
+            --task-definition "$NEW_ARN" \
             --force-new-deployment \
             --no-cli-pager
-          echo "✅ ${{ matrix.service }} deployed"
+
+          echo "✅ ${{ matrix.service }} deployed with $IMAGE"

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,8 +53,8 @@ COPY tsconfig.json ./
 # Build shared packages first (ignore errors for packages that don't exist)
 RUN pnpm --filter=@ai-job-portal/types build || true
 RUN pnpm --filter=@ai-job-portal/logger build || true
-RUN pnpm --filter=@ai-job-portal/common build || true
 RUN pnpm --filter=@ai-job-portal/database build || true
+RUN pnpm --filter=@ai-job-portal/common build || true
 RUN pnpm --filter=@ai-job-portal/aws build || true
 RUN pnpm --filter=@ai-job-portal/video-conferencing build || true
 


### PR DESCRIPTION
## Summary
- Split `docker-build-push.yml` into `deploy-dev.yml` and `deploy-staging.yml`
- Each env has isolated ECR repos (dev: `ai-job-portal/{svc}`, staging: `ai-job-portal-staging/{svc}`)
- Deploy step now registers new task def revision with updated image URI
- Fixed Dockerfile build order: database before common

## Changelog (2026-04-01)
- Separated deploy workflows per environment
- Fixed Dockerfile shared package build order