### PR TITLE
fix: harden amplify deploy workflows

### DIFF
--- a/.github/workflows/deploy-admin.yml
+++ b/.github/workflows/deploy-admin.yml
@@ -11,6 +11,10 @@ on:
           - staging
         default: dev
 
+concurrency:
+  group: amplify-admin-${{ inputs.environment }}
+  cancel-in-progress: false
+
 env:
   AWS_REGION: ap-south-1
   AMPLIFY_APP_ID: d107gebr3drm0w
@@ -19,13 +23,39 @@ env:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
+
+      - name: Wait for existing jobs to finish
+        run: |
+          MAX_WAIT=300
+          ELAPSED=0
+          while [ $ELAPSED -lt $MAX_WAIT ]; do
+            RUNNING=$(aws amplify list-jobs \
+              --app-id ${{ env.AMPLIFY_APP_ID }} \
+              --branch-name ${{ env.BRANCH }} \
+              --max-items 5 \
+              --query "jobSummaries[?status=='PENDING' || status=='RUNNING'] | length(@)" \
+              --output text)
+            if [ "$RUNNING" = "0" ]; then
+              echo "No active jobs, proceeding"
+              break
+            fi
+            echo "Waiting for $RUNNING active job(s) to finish... (${ELAPSED}s/${MAX_WAIT}s)"
+            sleep 15
+            ELAPSED=$((ELAPSED + 15))
+          done
+          if [ $ELAPSED -ge $MAX_WAIT ]; then
+            echo "::warning::Timed out waiting for existing jobs after ${MAX_WAIT}s, attempting deploy anyway"
+          fi
 
       - name: Trigger Amplify deployment
         id: deploy
@@ -42,26 +72,31 @@ jobs:
       - name: Wait for deployment
         run: |
           echo "Waiting for Amplify deployment to complete..."
-          while true; do
+          MAX_WAIT=600
+          ELAPSED=0
+          while [ $ELAPSED -lt $MAX_WAIT ]; do
             STATUS=$(aws amplify get-job \
               --app-id ${{ env.AMPLIFY_APP_ID }} \
               --branch-name ${{ env.BRANCH }} \
               --job-id ${{ steps.deploy.outputs.job_id }} \
               --query 'job.summary.status' \
               --output text)
-            echo "Status: $STATUS"
+            echo "Status: $STATUS (${ELAPSED}s/${MAX_WAIT}s)"
             case $STATUS in
               SUCCEED)
                 echo "Admin panel deployed successfully"
                 echo "URL: https://${{ env.BRANCH }}.${{ env.AMPLIFY_APP_ID }}.amplifyapp.com"
-                break
+                exit 0
                 ;;
               FAILED|CANCELLED)
-                echo "Deployment $STATUS"
+                echo "::error::Deployment $STATUS"
                 exit 1
                 ;;
               *)
                 sleep 15
+                ELAPSED=$((ELAPSED + 15))
                 ;;
             esac
           done
+          echo "::error::Deployment timed out after ${MAX_WAIT}s"
+          exit 1

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -11,6 +11,10 @@ on:
           - staging
         default: dev
 
+concurrency:
+  group: amplify-frontend-${{ inputs.environment }}
+  cancel-in-progress: false
+
 env:
   AWS_REGION: ap-south-1
   AMPLIFY_APP_ID: d3tubn69g0t2tw
@@ -19,13 +23,39 @@ env:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
+
+      - name: Wait for existing jobs to finish
+        run: |
+          MAX_WAIT=300
+          ELAPSED=0
+          while [ $ELAPSED -lt $MAX_WAIT ]; do
+            RUNNING=$(aws amplify list-jobs \
+              --app-id ${{ env.AMPLIFY_APP_ID }} \
+              --branch-name ${{ env.BRANCH }} \
+              --max-items 5 \
+              --query "jobSummaries[?status=='PENDING' || status=='RUNNING'] | length(@)" \
+              --output text)
+            if [ "$RUNNING" = "0" ]; then
+              echo "No active jobs, proceeding"
+              break
+            fi
+            echo "Waiting for $RUNNING active job(s) to finish... (${ELAPSED}s/${MAX_WAIT}s)"
+            sleep 15
+            ELAPSED=$((ELAPSED + 15))
+          done
+          if [ $ELAPSED -ge $MAX_WAIT ]; then
+            echo "::warning::Timed out waiting for existing jobs after ${MAX_WAIT}s, attempting deploy anyway"
+          fi
 
       - name: Trigger Amplify deployment
         id: deploy
@@ -42,26 +72,31 @@ jobs:
       - name: Wait for deployment
         run: |
           echo "Waiting for Amplify deployment to complete..."
-          while true; do
+          MAX_WAIT=600
+          ELAPSED=0
+          while [ $ELAPSED -lt $MAX_WAIT ]; do
             STATUS=$(aws amplify get-job \
               --app-id ${{ env.AMPLIFY_APP_ID }} \
               --branch-name ${{ env.BRANCH }} \
               --job-id ${{ steps.deploy.outputs.job_id }} \
               --query 'job.summary.status' \
               --output text)
-            echo "Status: $STATUS"
+            echo "Status: $STATUS (${ELAPSED}s/${MAX_WAIT}s)"
             case $STATUS in
               SUCCEED)
                 echo "Frontend deployed successfully"
                 echo "URL: https://${{ env.BRANCH }}.${{ env.AMPLIFY_APP_ID }}.amplifyapp.com"
-                break
+                exit 0
                 ;;
               FAILED|CANCELLED)
-                echo "❌ Deployment $STATUS"
+                echo "::error::Deployment $STATUS"
                 exit 1
                 ;;
               *)
                 sleep 15
+                ELAPSED=$((ELAPSED + 15))
                 ;;
             esac
           done
+          echo "::error::Deployment timed out after ${MAX_WAIT}s"
+          exit 1


### PR DESCRIPTION
## Summary
- Wait for existing Amplify jobs before triggering new deploy (prevents `LimitExceededException`)
- Add `concurrency` group per app+env so two devs can't deploy same app/env simultaneously
- Add 10min timeout on deployment wait (was infinite `while true` loop)
- Add 15min job-level timeout
- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` for `aws-actions/configure-aws-credentials@v4` Node.js 20 deprecation
- Amplify auto-build disabled on all branches — deploys are now manual via GitHub Actions only

## Changelog - 2026-04-06
- Hardened Amplify deploy workflows for frontend and admin panel

## Test plan
- [ ] Trigger "Deploy Frontend (Amplify)" workflow manually for dev
- [ ] Trigger "Deploy Admin Panel (Amplify)" workflow manually for staging
- [ ] Verify no auto-deploy on push to dev/staging branches