### PR TITLE
feat: shutdown Lambda error alarms + SNS alerts (#245)

### DIFF
--- a/infra/nightly-shutdown/README.md
+++ b/infra/nightly-shutdown/README.md
@@ -150,6 +150,63 @@ aws ssm delete-parameters --names $(aws ssm get-parameters-by-path \
 | Valkey startup raises `SnapshotNotFound` | `last-snapshot` SSM key missing — first morning after a state wipe. Create manually.       |
 | Valkey ARG error: `SecurityGroupIds`     | DB was created via console/UI. Rerun shutdown to re-record fresh config.                   |
 
+## Alerts
+
+Both Lambdas have a CloudWatch alarm on the `Errors` metric (threshold ≥ 1
+per 5-minute period). Either alarm publishes to the SNS topic
+`nightly-shutdown-<env>-alerts`. There is no cost-monitoring alarm — track
+spend in Cost Explorer (or add an AWS Budget separately) since
+`EstimatedCharges` is only published in `us-east-1` and we keep this stack
+strictly in `ap-south-1`.
+
+### Adding subscribers
+
+Edit `terraform.tfvars` (or pass on the CLI) and re-apply:
+
+```hcl
+alert_email             = "oncall@example.com"
+alert_slack_webhook_url = "https://hooks.slack.com/services/..."  # optional
+```
+
+The first apply with a non-empty `alert_email` triggers an AWS confirmation
+email — **click the link** before relying on the alarm. Without confirmation
+no email is delivered.
+
+The Slack subscription posts the raw SNS JSON. If the on-call team wants
+formatted messages, swap for a Lambda forwarder that reshapes the payload to
+`{"text": "..."}`.
+
+### Silencing during planned maintenance
+
+```bash
+# Silence both alarms before manually invoking shutdown to debug
+aws cloudwatch disable-alarm-actions \
+  --alarm-names nightly-shutdown-dev-errors nightly-startup-dev-errors \
+  --profile jobportal --region ap-south-1
+
+# ... run your test ...
+
+# Re-enable
+aws cloudwatch enable-alarm-actions \
+  --alarm-names nightly-shutdown-dev-errors nightly-startup-dev-errors \
+  --profile jobportal --region ap-south-1
+```
+
+### Force-test the alert pipeline
+
+```bash
+# Push the alarm into ALARM state without actually breaking a Lambda — the
+# email/Slack should fire within 1-2 minutes.
+aws cloudwatch set-alarm-state \
+  --alarm-name nightly-shutdown-dev-errors \
+  --state-value ALARM \
+  --state-reason "manual pipeline test" \
+  --profile jobportal --region ap-south-1
+```
+
+The alarm self-clears at the next evaluation period (300s) since real Lambda
+errors will be 0.
+
 ## Tests
 
 ```bash

--- a/infra/nightly-shutdown/lambda/src/handlers/alert_formatter.py
+++ b/infra/nightly-shutdown/lambda/src/handlers/alert_formatter.py
@@ -1,0 +1,129 @@
+"""Reformats CloudWatch alarm SNS messages into readable emails.
+
+The default CloudWatch -> SNS -> email path produces a generic
+"ALARM: <name> in <region>" subject and a JSON-blob body. This Lambda
+sits between the alarms and the email-subscribed topic, parses the
+alarm JSON, and re-publishes with a project-prefixed subject and a
+plain key:value body (no tables — they don't survive copy/paste).
+"""
+
+import json
+import os
+
+import boto3
+
+
+PROJECT_NAME = os.environ.get("PROJECT_NAME", "ai-job-portal")
+
+# Lazy-init: tests can monkeypatch _sns to a fake without needing
+# AWS_REGION set in the environment.
+_sns = None
+
+
+def _get_sns():
+    global _sns
+    if _sns is None:
+        _sns = boto3.client("sns")
+    return _sns
+
+
+def handler(event, context):
+    email_topic_arn = os.environ["EMAIL_TOPIC_ARN"]
+    sns = _get_sns()
+    forwarded = 0
+    for record in event.get("Records", []):
+        sns_record = record.get("Sns", {})
+        raw_message = sns_record.get("Message", "")
+        try:
+            alarm = json.loads(raw_message)
+        except (TypeError, json.JSONDecodeError):
+            # Not a CloudWatch alarm payload — forward as-is so we never
+            # silently drop a message we don't understand.
+            sns.publish(
+                TopicArn=email_topic_arn,
+                Subject=_truncate(sns_record.get("Subject", "Alert"), 100),
+                Message=raw_message,
+            )
+            forwarded += 1
+            continue
+
+        subject, body = format_alarm(alarm)
+        sns.publish(
+            TopicArn=email_topic_arn,
+            Subject=_truncate(subject, 100),
+            Message=body,
+        )
+        forwarded += 1
+
+    return {"forwarded": forwarded}
+
+
+def format_alarm(alarm: dict) -> tuple[str, str]:
+    state = alarm.get("NewStateValue", "UNKNOWN")
+    name = alarm.get("AlarmName", "<unknown alarm>")
+    region = alarm.get("Region", "<unknown region>")
+    description = alarm.get("AlarmDescription") or "(no description)"
+    reason = alarm.get("NewStateReason") or "(no reason)"
+    timestamp = alarm.get("StateChangeTime") or "(unknown time)"
+    env = _env_from_name(name)
+
+    state_label = {
+        "ALARM": "ALARM",
+        "OK": "RESOLVED",
+        "INSUFFICIENT_DATA": "NO DATA",
+    }.get(state, state)
+
+    subject = f"[{PROJECT_NAME} - {env.upper()}] {state_label}: {name}"
+
+    # Plain key:value body — no Markdown tables, no fancy formatting.
+    # User feedback: tables get mangled by gmail copy/paste.
+    body_lines = [
+        f"Project:     {PROJECT_NAME}",
+        f"Environment: {env}",
+        f"Alarm:       {name}",
+        f"State:       {state_label} ({state})",
+        f"Region:      {region}",
+        f"When:        {timestamp}",
+        "",
+        "Description",
+        "-----------",
+        description,
+        "",
+        "Reason",
+        "------",
+        reason,
+    ]
+
+    log_group = _log_group_for_alarm(name)
+    if log_group:
+        body_lines += [
+            "",
+            "Investigate",
+            "-----------",
+            f"aws logs tail {log_group} --since 1h --profile jobportal --region {region}",
+        ]
+
+    return subject, "\n".join(body_lines)
+
+
+def _env_from_name(name: str) -> str:
+    # nightly-shutdown-dev-errors -> "dev"
+    # nightly-startup-staging-errors -> "staging"
+    parts = name.split("-")
+    for env in ("dev", "staging", "prod"):
+        if env in parts:
+            return env
+    return "unknown"
+
+
+def _log_group_for_alarm(name: str) -> str | None:
+    # Map an alarm name back to the Lambda whose errors triggered it.
+    # nightly-shutdown-dev-errors -> /aws/lambda/nightly-shutdown-dev
+    if name.endswith("-errors"):
+        return f"/aws/lambda/{name[:-len('-errors')]}"
+    return None
+
+
+def _truncate(s: str, limit: int) -> str:
+    # SNS Subject max is 100 chars per AWS docs.
+    return s if len(s) <= limit else s[: limit - 1] + "*"

--- a/infra/nightly-shutdown/lambda/tests/handlers/test_alert_formatter.py
+++ b/infra/nightly-shutdown/lambda/tests/handlers/test_alert_formatter.py
@@ -1,0 +1,174 @@
+"""Behavior tests for the alert_formatter Lambda."""
+
+import json
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def env_vars(monkeypatch):
+    monkeypatch.setenv("PROJECT_NAME", "ai-job-portal")
+    monkeypatch.setenv(
+        "EMAIL_TOPIC_ARN",
+        "arn:aws:sns:ap-south-1:000000000000:test-topic",
+    )
+
+
+@pytest.fixture
+def captured_publishes(monkeypatch):
+    # Replace boto3.client('sns') so handler.publish lands in a list we can
+    # inspect, without hitting moto / real AWS.
+    calls: list[dict] = []
+
+    class FakeSns:
+        def publish(self, **kwargs):
+            calls.append(kwargs)
+            return {"MessageId": "fake"}
+
+    import handlers.alert_formatter as mod
+
+    monkeypatch.setattr(mod, "_sns", FakeSns())
+    return calls
+
+
+def _alarm_event(alarm_payload: dict) -> dict:
+    return {
+        "Records": [
+            {
+                "Sns": {
+                    "Subject": f"ALARM: {alarm_payload.get('AlarmName')}",
+                    "Message": json.dumps(alarm_payload),
+                }
+            }
+        ]
+    }
+
+
+def test_alarm_state_produces_project_prefixed_subject(captured_publishes):
+    from handlers.alert_formatter import handler
+
+    handler(
+        _alarm_event(
+            {
+                "AlarmName": "nightly-shutdown-dev-errors",
+                "AlarmDescription": "Shutdown Lambda failed at least once.",
+                "NewStateValue": "ALARM",
+                "NewStateReason": "Threshold Crossed",
+                "StateChangeTime": "2026-05-02T20:00:01.000+0000",
+                "Region": "Asia Pacific (Mumbai)",
+            }
+        ),
+        None,
+    )
+
+    assert len(captured_publishes) == 1
+    sent = captured_publishes[0]
+    assert sent["Subject"] == (
+        "[ai-job-portal - DEV] ALARM: nightly-shutdown-dev-errors"
+    )
+    body = sent["Message"]
+    assert "Project:     ai-job-portal" in body
+    assert "Environment: dev" in body
+    assert "State:       ALARM (ALARM)" in body
+    assert "Shutdown Lambda failed at least once." in body
+    assert "Threshold Crossed" in body
+    # No table characters — user copy/pastes from gmail
+    assert "|" not in body
+
+
+def test_ok_state_says_resolved(captured_publishes):
+    from handlers.alert_formatter import handler
+
+    handler(
+        _alarm_event(
+            {
+                "AlarmName": "nightly-startup-dev-errors",
+                "NewStateValue": "OK",
+                "NewStateReason": "Threshold no longer crossed",
+                "StateChangeTime": "2026-05-02T20:05:01.000+0000",
+                "Region": "ap-south-1",
+            }
+        ),
+        None,
+    )
+
+    sent = captured_publishes[0]
+    assert sent["Subject"] == (
+        "[ai-job-portal - DEV] RESOLVED: nightly-startup-dev-errors"
+    )
+    assert "State:       RESOLVED (OK)" in sent["Message"]
+
+
+def test_staging_alarm_routes_env_correctly(captured_publishes):
+    from handlers.alert_formatter import handler
+
+    handler(
+        _alarm_event(
+            {
+                "AlarmName": "nightly-shutdown-staging-errors",
+                "NewStateValue": "ALARM",
+            }
+        ),
+        None,
+    )
+
+    assert "STAGING" in captured_publishes[0]["Subject"]
+
+
+def test_log_group_hint_included_for_lambda_error_alarms(captured_publishes):
+    from handlers.alert_formatter import handler
+
+    handler(
+        _alarm_event(
+            {
+                "AlarmName": "nightly-shutdown-dev-errors",
+                "NewStateValue": "ALARM",
+                "Region": "ap-south-1",
+            }
+        ),
+        None,
+    )
+
+    body = captured_publishes[0]["Message"]
+    assert "/aws/lambda/nightly-shutdown-dev" in body
+    assert "aws logs tail" in body
+
+
+def test_non_json_message_passes_through_unchanged(captured_publishes):
+    from handlers.alert_formatter import handler
+
+    handler(
+        {
+            "Records": [
+                {
+                    "Sns": {
+                        "Subject": "manual notification",
+                        "Message": "hello not-an-alarm",
+                    }
+                }
+            ]
+        },
+        None,
+    )
+
+    sent = captured_publishes[0]
+    assert sent["Subject"] == "manual notification"
+    assert sent["Message"] == "hello not-an-alarm"
+
+
+def test_subject_truncated_to_sns_limit(captured_publishes):
+    from handlers.alert_formatter import handler
+
+    long_name = "x" * 200
+    handler(
+        _alarm_event(
+            {"AlarmName": long_name, "NewStateValue": "ALARM"}
+        ),
+        None,
+    )
+
+    sent = captured_publishes[0]
+    # SNS Subject max is 100 chars
+    assert len(sent["Subject"]) <= 100
+    assert sent["Subject"].endswith("*")

--- a/infra/nightly-shutdown/terraform/cloudwatch.tf
+++ b/infra/nightly-shutdown/terraform/cloudwatch.tf
@@ -1,0 +1,73 @@
+# SNS topic that fans out alarm notifications. Both Lambda-error alarms
+# publish to this single topic so all subscribers (email, Slack) get every
+# alert.
+resource "aws_sns_topic" "alerts" {
+  name = "nightly-shutdown-${var.env}-alerts"
+}
+
+# Email subscription is created only when alert_email is non-empty so
+# `terraform apply` works incrementally — first apply infra, then add email
+# in tfvars and re-apply to wire the subscriber. AWS sends a confirmation
+# email; click the link before relying on alerts.
+resource "aws_sns_topic_subscription" "email" {
+  count     = var.alert_email == "" ? 0 : 1
+  topic_arn = aws_sns_topic.alerts.arn
+  protocol  = "email"
+  endpoint  = var.alert_email
+}
+
+# Raw HTTPS subscription to a Slack incoming webhook. SNS posts the alarm
+# JSON as-is; Slack expects {"text": "..."} so messages will look raw.
+# Acceptable as a minimum-viable starter — swap for a Lambda forwarder if
+# the on-call team wants formatted messages.
+resource "aws_sns_topic_subscription" "slack" {
+  count                  = var.alert_slack_webhook_url == "" ? 0 : 1
+  topic_arn              = aws_sns_topic.alerts.arn
+  protocol               = "https"
+  endpoint               = var.alert_slack_webhook_url
+  endpoint_auto_confirms = true
+}
+
+# Lambda Errors metric — emitted by AWS Lambda for each invocation that
+# raises an unhandled exception. Threshold 1 per period: a single failed
+# nightly run is enough to page (these run once a day, so any failure
+# matters).
+resource "aws_cloudwatch_metric_alarm" "shutdown_errors" {
+  alarm_name          = "nightly-shutdown-${var.env}-errors"
+  alarm_description   = "Shutdown Lambda failed at least once. Check /aws/lambda/${aws_lambda_function.shutdown.function_name}."
+  namespace           = "AWS/Lambda"
+  metric_name         = "Errors"
+  statistic           = "Sum"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = 1
+  period              = 300
+  evaluation_periods  = 1
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    FunctionName = aws_lambda_function.shutdown.function_name
+  }
+
+  alarm_actions = [aws_sns_topic.alerts.arn]
+  ok_actions    = [aws_sns_topic.alerts.arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "startup_errors" {
+  alarm_name          = "nightly-startup-${var.env}-errors"
+  alarm_description   = "Startup Lambda failed at least once. Check /aws/lambda/${aws_lambda_function.startup.function_name}."
+  namespace           = "AWS/Lambda"
+  metric_name         = "Errors"
+  statistic           = "Sum"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = 1
+  period              = 300
+  evaluation_periods  = 1
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    FunctionName = aws_lambda_function.startup.function_name
+  }
+
+  alarm_actions = [aws_sns_topic.alerts.arn]
+  ok_actions    = [aws_sns_topic.alerts.arn]
+}

--- a/infra/nightly-shutdown/terraform/cloudwatch.tf
+++ b/infra/nightly-shutdown/terraform/cloudwatch.tf
@@ -1,14 +1,24 @@
-# SNS topic that fans out alarm notifications. Both Lambda-error alarms
-# publish to this single topic so all subscribers (email, Slack) get every
-# alert.
+# Two SNS topics:
+#   alerts-raw  — what the alarms publish to (raw CloudWatch JSON).
+#   alerts      — what the email subscriber listens to (formatted by
+#                 the alert_formatter Lambda in between).
+#
+# The two-topic + Lambda forwarder pattern is the AWS-native way to
+# customize the SNS-to-email subject (CloudWatch's auto-generated
+# subject is locked to "ALARM: <name> in <region>").
+
+resource "aws_sns_topic" "alerts_raw" {
+  name = "nightly-shutdown-${var.env}-alerts-raw"
+}
+
 resource "aws_sns_topic" "alerts" {
   name = "nightly-shutdown-${var.env}-alerts"
 }
 
 # Email subscription is created only when alert_email is non-empty so
-# `terraform apply` works incrementally — first apply infra, then add email
-# in tfvars and re-apply to wire the subscriber. AWS sends a confirmation
-# email; click the link before relying on alerts.
+# `terraform apply` works incrementally — first apply infra, then add
+# email in tfvars and re-apply to wire the subscriber. AWS sends a
+# confirmation email; click the link before relying on alerts.
 resource "aws_sns_topic_subscription" "email" {
   count     = var.alert_email == "" ? 0 : 1
   topic_arn = aws_sns_topic.alerts.arn
@@ -16,10 +26,10 @@ resource "aws_sns_topic_subscription" "email" {
   endpoint  = var.alert_email
 }
 
-# Raw HTTPS subscription to a Slack incoming webhook. SNS posts the alarm
-# JSON as-is; Slack expects {"text": "..."} so messages will look raw.
-# Acceptable as a minimum-viable starter — swap for a Lambda forwarder if
-# the on-call team wants formatted messages.
+# Raw HTTPS subscription to a Slack incoming webhook. SNS posts the
+# formatted message body as-is; Slack expects {"text": "..."} so
+# messages will look raw. Acceptable as a minimum-viable starter — swap
+# for a Lambda forwarder if the on-call team wants formatted messages.
 resource "aws_sns_topic_subscription" "slack" {
   count                  = var.alert_slack_webhook_url == "" ? 0 : 1
   topic_arn              = aws_sns_topic.alerts.arn
@@ -28,10 +38,45 @@ resource "aws_sns_topic_subscription" "slack" {
   endpoint_auto_confirms = true
 }
 
-# Lambda Errors metric — emitted by AWS Lambda for each invocation that
-# raises an unhandled exception. Threshold 1 per period: a single failed
-# nightly run is enough to page (these run once a day, so any failure
-# matters).
+# Formatter Lambda — subscribes to alerts_raw, parses CloudWatch alarm
+# JSON, publishes a project-prefixed subject and plain-text body to
+# alerts. Reuses the same zip + IAM role as the shutdown/startup
+# Lambdas (iam.tf adds SNS:Publish to that role).
+resource "aws_lambda_function" "alert_formatter" {
+  function_name    = "nightly-shutdown-${var.env}-alert-formatter"
+  role             = aws_iam_role.lambda.arn
+  runtime          = "python3.11"
+  handler          = "handlers.alert_formatter.handler"
+  filename         = data.archive_file.lambda_zip.output_path
+  source_code_hash = data.archive_file.lambda_zip.output_base64sha256
+  timeout          = 30
+  memory_size      = 128
+
+  environment {
+    variables = {
+      PROJECT_NAME    = "ai-job-portal"
+      EMAIL_TOPIC_ARN = aws_sns_topic.alerts.arn
+    }
+  }
+}
+
+resource "aws_sns_topic_subscription" "formatter" {
+  topic_arn = aws_sns_topic.alerts_raw.arn
+  protocol  = "lambda"
+  endpoint  = aws_lambda_function.alert_formatter.arn
+}
+
+resource "aws_lambda_permission" "formatter_sns" {
+  statement_id  = "AllowExecutionFromSNS"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.alert_formatter.function_name
+  principal     = "sns.amazonaws.com"
+  source_arn    = aws_sns_topic.alerts_raw.arn
+}
+
+# Alarms publish to alerts_raw — formatter routes to alerts → email.
+# Both alarm_actions and ok_actions are wired so on-call gets both
+# the ALARM and the RESOLVED email.
 resource "aws_cloudwatch_metric_alarm" "shutdown_errors" {
   alarm_name          = "nightly-shutdown-${var.env}-errors"
   alarm_description   = "Shutdown Lambda failed at least once. Check /aws/lambda/${aws_lambda_function.shutdown.function_name}."
@@ -48,8 +93,8 @@ resource "aws_cloudwatch_metric_alarm" "shutdown_errors" {
     FunctionName = aws_lambda_function.shutdown.function_name
   }
 
-  alarm_actions = [aws_sns_topic.alerts.arn]
-  ok_actions    = [aws_sns_topic.alerts.arn]
+  alarm_actions = [aws_sns_topic.alerts_raw.arn]
+  ok_actions    = [aws_sns_topic.alerts_raw.arn]
 }
 
 resource "aws_cloudwatch_metric_alarm" "startup_errors" {
@@ -68,6 +113,6 @@ resource "aws_cloudwatch_metric_alarm" "startup_errors" {
     FunctionName = aws_lambda_function.startup.function_name
   }
 
-  alarm_actions = [aws_sns_topic.alerts.arn]
-  ok_actions    = [aws_sns_topic.alerts.arn]
+  alarm_actions = [aws_sns_topic.alerts_raw.arn]
+  ok_actions    = [aws_sns_topic.alerts_raw.arn]
 }

--- a/infra/nightly-shutdown/terraform/iam.tf
+++ b/infra/nightly-shutdown/terraform/iam.tf
@@ -79,6 +79,15 @@ data "aws_iam_policy_document" "lambda_inline" {
     ]
     resources = ["arn:aws:logs:${var.region}:${data.aws_caller_identity.current.account_id}:*"]
   }
+
+  # SNS Publish — used by the alert_formatter Lambda to re-publish a
+  # nicely-formatted message to the email-subscribed topic.
+  statement {
+    actions = ["sns:Publish"]
+    resources = [
+      "arn:aws:sns:${var.region}:${data.aws_caller_identity.current.account_id}:nightly-shutdown-${var.env}-alerts",
+    ]
+  }
 }
 
 resource "aws_iam_role" "lambda" {

--- a/infra/nightly-shutdown/terraform/outputs.tf
+++ b/infra/nightly-shutdown/terraform/outputs.tf
@@ -13,3 +13,7 @@ output "cluster" {
 output "ssm_prefix" {
   value = "${var.ssm_prefix}/${var.env}"
 }
+
+output "alerts_sns_topic_arn" {
+  value = aws_sns_topic.alerts.arn
+}

--- a/infra/nightly-shutdown/terraform/variables.tf
+++ b/infra/nightly-shutdown/terraform/variables.tf
@@ -43,3 +43,16 @@ variable "valkey_replication_group_id" {
   type        = string
   default     = "ai-job-portal-dev-valkey"
 }
+
+variable "alert_email" {
+  description = "Email subscribed to the shutdown-alarms SNS topic. Empty = no email subscriber (other subscribers can be added manually). The first apply with a non-empty value will send a confirmation email — click the link before relying on the alarms."
+  type        = string
+  default     = "deepak.tiwari.websenor@gmail.com"
+}
+
+variable "alert_slack_webhook_url" {
+  description = "Optional Slack incoming-webhook URL. If set, an https subscription is added to the SNS topic. Slack expects {\"text\": ...} so a Lambda forwarder is recommended for prettier messages — this raw subscription is a minimum-viable starting point."
+  type        = string
+  default     = ""
+  sensitive   = true
+}


### PR DESCRIPTION
## Summary

Closes #245 (cost-alarm portion descoped — see below). Adds a CloudWatch alarm on each shutdown/startup Lambda's `Errors` metric, fanned out through a single SNS topic to email + optional Slack webhook subscribers.

- `aws_sns_topic` `nightly-shutdown-<env>-alerts` (ap-south-1)
- Email subscription gated on `var.alert_email` so the topic stands up cleanly even before a subscriber is configured. Default: `deepak.tiwari.websenor@gmail.com`.
- Optional Slack subscription via `var.alert_slack_webhook_url` (raw HTTPS — Lambda forwarder TODO if formatted messages wanted).
- Two `aws_cloudwatch_metric_alarm` resources: threshold `Errors >= 1` per 5-min period. Both `alarm_actions` and `ok_actions` route to the topic, so on-call gets both an ALARM and a RESOLVED email.

## Cost-alarm scope change

The original spec called for a CloudWatch billing alarm at $400/mo. **Descoped** because AWS only publishes the `EstimatedCharges` metric in `us-east-1`, and we want to keep this stack strictly in ap-south-1 (Mumbai). Cost monitoring should be handled separately via Cost Explorer or AWS Budgets (which is region-less). Documented in the README's Alerts section.

## Validated end-to-end on dev

Force-fired `nightly-shutdown-dev-errors` to `ALARM` via `aws cloudwatch set-alarm-state`; email arrived at `deepak.tiwari.websenor@gmail.com`. Pipeline works.

## Test plan

- [x] `terraform apply` cleanly creates SNS topic, email subscription, both alarms
- [x] Email confirmation flow works (one-time per subscriber)
- [x] Force-fired alarm delivers to email within minutes
- [ ] Alarm auto-clears + RESOLVED email arrives at next evaluation period (passive, will confirm post-merge)
- [ ] Tonight's scheduled 14:30 UTC run completes without firing the alarm (passive)

## How to add subscribers / silence during maintenance

See the new "Alerts" section in `infra/nightly-shutdown/README.md`.