### PR TITLE
feat: extend nightly shutdown to staging cluster (#247)

### DIFF
--- a/infra/nightly-shutdown/README.md
+++ b/infra/nightly-shutdown/README.md
@@ -1,15 +1,20 @@
 # Nightly Shutdown — ECS + RDS + Valkey
 
-Automation that pauses every billable dev resource on weekday nights and
-restores them on weekday mornings:
+Automation that pauses every billable dev/staging resource on weekday nights
+and restores them on weekday mornings:
 
-- **ECS**: scale every service in `ai-job-portal-dev` to `desired-count=0`
-- **RDS**: stop the `ai-job-portal-dev` DB instance (state-aware — only
+- **ECS**: scale every service in `ai-job-portal-<env>` to `desired-count=0`
+- **RDS**: stop the `ai-job-portal-<env>` DB instance (state-aware — only
   restarts what we stopped)
-- **Valkey**: snapshot+delete the `ai-job-portal-dev-valkey` replication
+- **Valkey**: snapshot+delete the `ai-job-portal-<env>-valkey` replication
   group, recreate from snapshot on startup
 
-Issues: #240 added ECS; #244 added RDS + Valkey + ScheduleOrchestrator.
+Each env (dev / staging) runs as its own Terraform workspace with isolated
+SNS topics, alarms, Lambda functions, and EventBridge rules — failure or
+silencing in one env can't affect the other.
+
+Issues: #240 added ECS; #244 added RDS + Valkey + ScheduleOrchestrator;
+#245 added alarms; #247 added staging.
 
 ## Architecture
 
@@ -68,19 +73,48 @@ until Monday 09:00 IST.
 
 ## Deploy
 
+Per-environment isolation uses Terraform workspaces — each env gets its own
+state file, so applies don't cross-contaminate.
+
+### Initial deploy
+
 ```bash
 cd terraform
 terraform init
-terraform plan -var env=dev
+
+# dev (default workspace)
 terraform apply -var env=dev
-```
 
-To deploy a second copy for staging:
-
-```bash
+# staging
 terraform workspace new staging
 terraform apply -var env=staging
 ```
+
+### Subsequent deploys
+
+```bash
+# dev
+terraform workspace select default
+terraform apply -var env=dev
+
+# staging
+terraform workspace select staging
+terraform apply -var env=staging
+```
+
+Per-env identifiers (RDS instance ID, Valkey replication-group ID) are
+auto-resolved from `var.env` via `locals.tf` — no `-var rds_db_instance_id=...`
+etc. needed. Override is still possible if you point at a non-standard
+resource.
+
+### Workspaces gotchas
+
+- `terraform workspace list` to see which workspace is active. Operating on
+  the wrong workspace with the wrong `-var env=...` will silently produce a
+  confusing diff.
+- Both workspaces share the same `terraform/` directory and the same code,
+  so a code change applies cleanly to both — just remember to apply twice
+  (once per workspace).
 
 ## Manual override
 

--- a/infra/nightly-shutdown/terraform/iam.tf
+++ b/infra/nightly-shutdown/terraform/iam.tf
@@ -42,7 +42,7 @@ data "aws_iam_policy_document" "lambda_inline" {
       "rds:StartDBInstance",
     ]
     resources = [
-      "arn:aws:rds:${var.region}:${data.aws_caller_identity.current.account_id}:db:${var.rds_db_instance_id}"
+      "arn:aws:rds:${var.region}:${data.aws_caller_identity.current.account_id}:db:${local.rds_db_instance_id}"
     ]
   }
 

--- a/infra/nightly-shutdown/terraform/lambda.tf
+++ b/infra/nightly-shutdown/terraform/lambda.tf
@@ -12,8 +12,8 @@ locals {
   lambda_env = {
     SHUTDOWN_ENV                = var.env
     STATE_SSM_PREFIX            = var.ssm_prefix
-    RDS_DB_INSTANCE_ID          = var.rds_db_instance_id
-    VALKEY_REPLICATION_GROUP_ID = var.valkey_replication_group_id
+    RDS_DB_INSTANCE_ID          = local.rds_db_instance_id
+    VALKEY_REPLICATION_GROUP_ID = local.valkey_replication_group_id
   }
 }
 

--- a/infra/nightly-shutdown/terraform/locals.tf
+++ b/infra/nightly-shutdown/terraform/locals.tf
@@ -1,0 +1,30 @@
+# Per-environment identifier defaults. Lets `terraform apply -var env=staging`
+# auto-resolve the right RDS instance + Valkey replication group without the
+# operator having to remember every -var flag.
+#
+# Override is still possible: pass `-var rds_db_instance_id=...` to point at
+# a non-standard instance.
+locals {
+  per_env_defaults = {
+    dev = {
+      rds_db_instance_id          = "ai-job-portal-dev"
+      valkey_replication_group_id = "ai-job-portal-dev-valkey"
+    }
+    staging = {
+      rds_db_instance_id          = "ai-job-portal-staging"
+      valkey_replication_group_id = "ai-job-portal-staging-valkey"
+    }
+  }
+
+  # Fall back to the per-env default only if the variable was left blank.
+  rds_db_instance_id = (
+    var.rds_db_instance_id != ""
+    ? var.rds_db_instance_id
+    : local.per_env_defaults[var.env].rds_db_instance_id
+  )
+  valkey_replication_group_id = (
+    var.valkey_replication_group_id != ""
+    ? var.valkey_replication_group_id
+    : local.per_env_defaults[var.env].valkey_replication_group_id
+  )
+}

--- a/infra/nightly-shutdown/terraform/variables.tf
+++ b/infra/nightly-shutdown/terraform/variables.tf
@@ -12,6 +12,11 @@ variable "env" {
   description = "Target environment cluster (dev / staging). Cluster name is derived as ai-job-portal-<env>."
   type        = string
   default     = "dev"
+
+  validation {
+    condition     = contains(["dev", "staging"], var.env)
+    error_message = "env must be one of: dev, staging."
+  }
 }
 
 variable "ssm_prefix" {
@@ -33,15 +38,15 @@ variable "startup_cron" {
 }
 
 variable "rds_db_instance_id" {
-  description = "RDS DB instance identifier to stop/start nightly."
+  description = "RDS DB instance identifier to stop/start nightly. Empty = derive from var.env via locals.tf (recommended)."
   type        = string
-  default     = "ai-job-portal-dev"
+  default     = ""
 }
 
 variable "valkey_replication_group_id" {
-  description = "ElastiCache Valkey replication-group ID to snapshot+delete nightly."
+  description = "ElastiCache Valkey replication-group ID to snapshot+delete nightly. Empty = derive from var.env via locals.tf (recommended)."
   type        = string
-  default     = "ai-job-portal-dev-valkey"
+  default     = ""
 }
 
 variable "alert_email" {


### PR DESCRIPTION
## Summary

Closes #247. Extends the nightly-shutdown automation (ECS + RDS + Valkey + alarms + email formatter) to operate on the \`ai-job-portal-staging\` cluster alongside dev. Each env runs as its own Terraform workspace with isolated state files, SNS topics, alarms, and Lambdas — failure or silencing in one env can't affect the other.

## What changed

- **\`locals.tf\`** (new) — per-env identifier mapping (\`dev\`/\`staging\` → RDS instance ID + Valkey RG ID) so \`terraform apply -var env=staging\` auto-resolves the right resources without per-flag overrides.
- **\`variables.tf\`** — RDS + Valkey ID defaults switched to empty string (locals fallback); \`env\` validated against {dev, staging}.
- **\`lambda.tf\` + \`iam.tf\`** — \`var.rds_db_instance_id\` / \`var.valkey_replication_group_id\` references repointed at the new \`local.*\` equivalents. No code changes — handlers were already env-driven via \`SHUTDOWN_ENV\` env var since #240.
- **README** — workspace-per-env operation guide, gotchas around active-workspace selection, run-twice-on-code-change reminder.

## Architecture

```
                        terraform workspace = default          terraform workspace = staging
                        ----------------------------          ------------------------------
EventBridge (UTC)       nightly-shutdown-dev                  nightly-shutdown-staging
                            ↓                                     ↓
Shutdown Lambda         scales ai-job-portal-dev               scales ai-job-portal-staging
                            ↓                                     ↓
SSM state               /nightly-shutdown/dev/...              /nightly-shutdown/staging/...
                            ↓                                     ↓
Alarms + SNS topics     nightly-shutdown-dev-alerts(-raw)      nightly-shutdown-staging-alerts(-raw)
                            ↓                                     ↓
Email                   deepak.tiwari.websenor@gmail.com       deepak.tiwari.websenor@gmail.com
```

Both envs share the same code zip and IAM role pattern; only the resource names differ.

## Validated end-to-end on staging

Live smoke test on the \`ai-job-portal-staging\` cluster:

**Shutdown** (\`{"status": "ok", "errors": []}\`):
- 11/11 ECS services 1→0
- RDS \`available\` → \`stopped\`
- Valkey RG snapshotted (\`ai-job-portal-staging-valkey-final-20260502\`) + deleted
- 14 SSM markers recorded under \`/nightly-shutdown/staging/...\` (no collision with dev)

**Startup** (Lambda completed in 3m 22s):
- Valkey RG \`available\` again, cache.t3.micro restored from snapshot
- RDS \`stopped\` → \`available\` (post-stop cooldown handled by retry logic from #244)
- 11/11 ECS services 0→1
- RDS marker cleared post-success

**Email pipeline (#245)**: confirmation email arrived, force-fired alarms validated separately on dev — same code path, same Lambda formatter, runs identically on staging.

## Test plan

- [x] \`terraform apply\` on \`default\` workspace = no-op (locals refactor invisible to existing dev infra)
- [x] \`terraform workspace new staging && apply\` creates 18 resources cleanly
- [x] Staging shutdown observed end-to-end (ECS+RDS+Valkey + state recording)
- [x] Staging startup observed end-to-end (recreate from snapshot, restore counts, clear marker)
- [x] Staging email subscription confirmed
- [ ] Tonight's 14:30 UTC scheduled run completes without alarms in both envs (passive)