### PR TITLE
fix: otp generation behaviour changed for automation testing

### DIFF
--- a/apps/auth-service/src/auth/auth.service.ts
+++ b/apps/auth-service/src/auth/auth.service.ts
@@ -326,7 +326,7 @@ export class AuthService {
 
     // Auto-resend email verification OTP if not verified (non-blocking, frontend handles redirect)
     if (!user.isVerified) {
-      const otp = generateOtp();
+      const otp = isNonProd ? '123456' : generateOtp();
 
       try {
         await this.redis.setex(

--- a/apps/auth-service/src/company-registration/company-registration.service.ts
+++ b/apps/auth-service/src/company-registration/company-registration.service.ts
@@ -295,17 +295,22 @@ export class CompanyRegistrationService {
     }
 
     // Verify OTP via Cognito confirmSignUp
-    try {
-      await this.cognitoService.confirmSignUp(session.email, dto.otp);
-    } catch (error: any) {
-      if (error.name === 'CodeMismatchException') {
+    const isNonProd = ['development', 'staging'].includes(process.env.NODE_ENV || '');
+    const isTestOtp = dto.otp === '123456';
+
+    if (!isNonProd || !isTestOtp) {
+      try {
+        await this.cognitoService.confirmSignUp(session.email, dto.otp);
+      } catch (error: any) {
+        if (error.name === 'CodeMismatchException') {
+          throw new BadRequestException('Invalid OTP. Please try again.');
+        }
+        if (error.name === 'ExpiredCodeException') {
+          throw new BadRequestException('OTP has expired. Please request a new one.');
+        }
+        this.logger.error(`Cognito confirmSignUp failed: ${error.message}`);
         throw new BadRequestException('Invalid OTP. Please try again.');
       }
-      if (error.name === 'ExpiredCodeException') {
-        throw new BadRequestException('OTP has expired. Please request a new one.');
-      }
-      this.logger.error(`Cognito confirmSignUp failed: ${error.message}`);
-      throw new BadRequestException('Invalid OTP. Please try again.');
     }
 
     session.emailVerified = true;


### PR DESCRIPTION
- OTP generation Behavior changed
- Staging/Development, both the test OTP (123456) and the real email OTP will work. In production, only the real OTP    
  works.