### PR TITLE
chore(husky): build changed services before commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,21 @@
-npx lint-staged
+npx lint-staged || exit 1
+
+staged_files="$(git diff --cached --name-only --diff-filter=ACMR)"
+
+# Backend services only — frontend (apps/job-board-web) intentionally excluded
+services="api-gateway auth-service user-service job-service application-service admin-service notification-service payment-service messaging-service recommendation-service"
+
+# Build (type-check) every changed service. Goes through turbo so shared
+# package dependencies are built too and unchanged builds hit the cache.
+for svc in $services; do
+  if printf '%s\n' "$staged_files" | grep -q "^apps/$svc/"; then
+    echo "pre-commit: building $svc"
+    pnpm build --filter="$svc" || exit 1
+  fi
+done
+
+# Shared packages affect every service — build the whole workspace
+if printf '%s\n' "$staged_files" | grep -q '^packages/'; then
+  echo "pre-commit: packages changed, building workspace"
+  pnpm build || exit 1
+fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,3 @@
+# Full workspace build before push — turbo cache makes this fast when
+# pre-commit already built the changed services
+pnpm build || exit 1

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "description": "AI Job Portal - NestJS Microservices",
   "scripts": {
+    "prepare": "husky",
     "build": "turbo run build",
     "dev": "turbo run dev --concurrency=20",
     "dev:gateway": "turbo run dev --filter=api-gateway",


### PR DESCRIPTION
Pre-commit builds each staged backend service through turbo (shared package changes trigger a full workspace build); pre-push builds the whole workspace. prepare script installs hooks on pnpm install. Hooks build only — service tests are live-service E2E and can't run in a hook.