### PR TITLE
build: make husky prepare script safe for prod installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "AI Job Portal - NestJS Microservices",
   "scripts": {
-    "prepare": "husky",
+    "prepare": "husky || true",
     "build": "turbo run build",
     "dev": "turbo run dev --concurrency=20",
     "dev:gateway": "turbo run dev --filter=api-gateway",


### PR DESCRIPTION
Docker stage 3 runs `pnpm install --prod`; husky is a devDependency so the bare `husky` prepare script exits 1 and fails every service image build. `|| true` no-ops when husky is absent, still installs hooks in dev.